### PR TITLE
Switch to showing real speed when near exploding & remove hit.distance from calculations & make meter overflow slightly less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,9 @@
 - Fixed critical warning sound working improperly
 	- Before when a player first reached critical, the warning sound would play properly. However, toggling the jetpack while in critical would cause the warning sound to end and not reactivate
 	- Now the warning sound will continue to play, even if you toggle the jetpack while in critical
+
+## 2.?.? (remember to fill version number)
+
+- Fixed warning meter not going full while maintaining steady high speed, causing jetpack to explode
+- Removed a mostly unnecessary variable from the warning meter fill logic, which would cause sudden changes in the meter
+	- Removed meter fill dampening due to it no longer being necessary, making the meter more responsive

--- a/Patches.cs
+++ b/Patches.cs
@@ -8,11 +8,7 @@ namespace JetpackWarning {
     class Patches {
         static private bool playJetpackCritical = false;
         static private bool playingJetpackCritical = false;
-        static private float currentFill = 0f;
-        static private float fillVelocity = 0f;
-
         static private float criticalFill = 0.75f;
-        static private float fillTime = 0.1f;
 
         [HarmonyPatch(typeof(PlayerControllerB), "LateUpdate")]
         [HarmonyPostfix]
@@ -42,14 +38,12 @@ namespace JetpackWarning {
                     fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.25f) >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.25f)) / 50f : 0f;
                     fill = Mathf.Lerp(fill_acceleration, fill_real_speed, interpolation);
 
-                    JetpackWarningPlugin.meter.GetComponent<Image>().fillAmount = currentFill;
-                    JetpackWarningPlugin.warning.SetActive(currentFill > criticalFill);
+                    JetpackWarningPlugin.meter.GetComponent<Image>().fillAmount = fill;
+                    JetpackWarningPlugin.warning.SetActive(fill > criticalFill);
 
-                    currentFill = Mathf.SmoothDamp(currentFill, fill, ref fillVelocity, fillTime);
+                    playJetpackCritical = fill > criticalFill;
 
-                    playJetpackCritical = currentFill > criticalFill;
-
-                    Color meterColor = Color.Lerp(new Color(1f, 0.82f, 0.405f, 1f), new Color(0.769f, 0.243f, 0.243f, 1f), currentFill);
+                    Color meterColor = Color.Lerp(new Color(1f, 0.82f, 0.405f, 1f), new Color(0.769f, 0.243f, 0.243f, 1f), fill);
 
                     JetpackWarningPlugin.meter.GetComponent<Image>().color = meterColor;
                     JetpackWarningPlugin.frame.GetComponent<Image>().color = meterColor;

--- a/Patches.cs
+++ b/Patches.cs
@@ -24,9 +24,6 @@ namespace JetpackWarning {
 
                     Vector3 forces = (Vector3)typeof(JetpackItem).GetField("forces", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(jetpack);
                     float jetpackPower = (float)typeof(JetpackItem).GetField("jetpackPower", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(jetpack);
-
-                    RaycastHit hit;
-                    Physics.Raycast(__instance.transform.position, forces, out hit, 25f, StartOfRound.Instance.allPlayersCollideWithMask);
                     
                     float fill_acceleration, fill_real_speed, fill, interpolation;
                     
@@ -41,8 +38,8 @@ namespace JetpackWarning {
                     if(forces.magnitude > 47){ // Switch meter to show real speed when near exploding
                         interpolation = Mathf.Clamp(forces.magnitude / 3f - 15.6666f, 0, 1f); // forces.magnitude 47-50, 0 to 1
                     }
-                    fill_real_speed = forces.magnitude - hit.distance >= 0 ? (forces.magnitude- hit.distance) / 50f : 0f;
-                    fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.2f) - hit.distance >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.2f) - hit.distance) / 50f : 0f;
+                    fill_real_speed = forces.magnitude >= 0 ? forces.magnitude / 50f : 0f;
+                    fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.2f) >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.2f)) / 50f : 0f;
                     fill = Mathf.Lerp(fill_acceleration, fill_real_speed, interpolation);
 
                     JetpackWarningPlugin.meter.GetComponent<Image>().fillAmount = currentFill;

--- a/Patches.cs
+++ b/Patches.cs
@@ -38,6 +38,9 @@ namespace JetpackWarning {
                     else{
                         interpolation = 0.5f - Mathf.Clamp(jetpackPower / 20f - 4f, 0, 1f) / 2f; // jetpackPower 80-100, 0.5 to 0
                     }
+                    if(forces.magnitude > 47){ // Switch meter to show real speed when near exploding
+                        interpolation = Mathf.Clamp(forces.magnitude / 3f - 15.6666f, 0, 1f); // forces.magnitude 47-50, 0 to 1
+                    }
                     fill_real_speed = forces.magnitude - hit.distance >= 0 ? (forces.magnitude- hit.distance) / 50f : 0f;
                     fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.2f) - hit.distance >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.2f) - hit.distance) / 50f : 0f;
                     fill = Mathf.Lerp(fill_acceleration, fill_real_speed, interpolation);

--- a/Patches.cs
+++ b/Patches.cs
@@ -39,7 +39,7 @@ namespace JetpackWarning {
                         interpolation = Mathf.Clamp(forces.magnitude / 3f - 15.6666f, 0, 1f); // forces.magnitude 47-50, 0 to 1
                     }
                     fill_real_speed = forces.magnitude >= 0 ? forces.magnitude / 50f : 0f;
-                    fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.2f) >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.2f)) / 50f : 0f;
+                    fill_acceleration = (forces.magnitude/2) + (jetpackPower/2.25f) >= 0 ? ((forces.magnitude/2) + (jetpackPower/2.25f)) / 50f : 0f;
                     fill = Mathf.Lerp(fill_acceleration, fill_real_speed, interpolation);
 
                     JetpackWarningPlugin.meter.GetComponent<Image>().fillAmount = currentFill;


### PR DESCRIPTION
Yet again I tried to separate some of these commits, but I screwed up and I can't figure out how to undo it so I hope you like all of the changes.

The reasoning behind removing hit.distance from calculations: https://github.com/klepticat/JetpackWarning/issues/4#issue-2033324335 (and as a result of this, we can remove the warning meter dampening)

And I made the meter overflow slightly less, meaning now when the meter visually fills up, you are slightly closer to exploding.